### PR TITLE
Update BadUseOfReturnValue.java

### DIFF
--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadUseOfReturnValue.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/detect/BadUseOfReturnValue.java
@@ -62,8 +62,9 @@ public class BadUseOfReturnValue extends BytecodeScanningDetector {
         }
 
         if (seen == Const.INVOKEVIRTUAL && "readLine".equals(getNameConstantOperand())
-                && "()Ljava/lang/String;".equals(getSigConstantOperand()) && getClassConstantOperand().startsWith("java/io")
-                && !"java/io/LineNumberReader".equals(getClassConstantOperand())) {
+                && "()Ljava/lang/String;".equals(getSigConstantOperand()) && 
+                ((getClassConstantOperand().startsWith("java/io") && !"java/io/LineNumberReader".equals(getClassConstantOperand())) ||
+                (getClassConstantOperand().startsWith("javax.imageio.stream")))) {
             readLineOnTOS = true;
         } else if (readLineOnTOS) {
             if (seen == Const.IFNULL || seen == Const.IFNONNULL) {


### PR DESCRIPTION
Fix issues: (#1821, #1820, #1819, #1818)
Make RV_DONT_JUST_NULL_CHECK_READLINE can detect these functions.